### PR TITLE
refactor/blogpost-draft

### DIFF
--- a/src/content/blogpost/chaos-game/index.en.svx
+++ b/src/content/blogpost/chaos-game/index.en.svx
@@ -4,7 +4,6 @@ description: "Can be anything deterministic hidden behind the random?"
 keywords: [ "generative art", "math" ]
 lang: en
 layout: blogpost
-published: true
 slug: "the-chaos-game"
 title: "The Chaos Game: The randomness against determinism"
 translation: { lang: "русский", slug: "игра-хаоса" }

--- a/src/content/blogpost/chaos-game/index.ru.svx
+++ b/src/content/blogpost/chaos-game/index.ru.svx
@@ -4,7 +4,6 @@ description: "Может ли что-то детерменистичное ск�
 keywords: [ "generative art", "math" ]
 lang: ru
 layout: blogpost
-published: true
 slug: "игра-хаоса"
 title: "Игра Хаоса: случайность против детерменизма"
 translation: { lang: "english", slug: "the-chaos-game" }

--- a/src/content/blogpost/css-only-masonry/index.en.svx
+++ b/src/content/blogpost/css-only-masonry/index.en.svx
@@ -4,7 +4,6 @@ description: "Build Masonry-like layout image gallery component using the modern
 keywords: [ "css", "web" ]
 lang: en
 layout: blogpost
-published: true
 slug: "masonry-image-gallery-with-almost-pure-css"
 title: "Masonry Image Gallery Layout with (almost) pure CSS"
 translation: { lang: "русский", slug: "галерея-изображений-в-раскладке-masonry-на-почти-чистом-css" }
@@ -108,7 +107,7 @@ The output is passed down into using custom properties.
 ```css
 .masonry > .masonry-item {
   grid-row-end: span var(--masonry-item-row);
-  grid-column-end: span var(--masonry-item-column); 
+  grid-column-end: span var(--masonry-item-column);
 }
 ```
 
@@ -157,7 +156,7 @@ Basic [Svelte][svelte] component implementation may look like this:
 
   .masonry > .item {
     grid-row-end: span var(--masonry-item-row);
-    grid-column-end: span var(--masonry-item-column); 
+    grid-column-end: span var(--masonry-item-column);
   }
 </style>
 ```

--- a/src/content/blogpost/css-only-masonry/index.ru.svx
+++ b/src/content/blogpost/css-only-masonry/index.ru.svx
@@ -4,7 +4,6 @@ description: "Реализуем компонент для галереи изо
 keywords: [ "css", "web" ]
 lang: ru
 layout: blogpost
-published: true
 slug: "галерея-изображений-в-раскладке-masonry-на-почти-чистом-css"
 title: "Галерея изображений в раскладке Masonry на (почти) чистом CSS"
 translation: { lang: "english", slug: "masonry-image-gallery-with-almost-pure-css" }
@@ -112,7 +111,7 @@ const calcMasonryItemSpan = (size, scale) => Math.floor(size / scale);
 ```css
 .masonry > .masonry-item {
   grid-row-end: span var(--masonry-item-row);
-  grid-column-end: span var(--masonry-item-column); 
+  grid-column-end: span var(--masonry-item-column);
 }
 ```
 
@@ -161,14 +160,14 @@ const calcMasonryItemSpan = (size, scale) => Math.floor(size / scale);
 
   .masonry > .item {
     grid-row-end: span var(--masonry-item-row);
-    grid-column-end: span var(--masonry-item-column); 
+    grid-column-end: span var(--masonry-item-column);
   }
 </style>
 ```
 
 ## Выводы
 
-Сложно назвать это приближение действительно достойной заменой полноценной раскладки Masonry, со свойственными ему ограничениями. Нарушение визуального порядка элементов является серьёзной проблемой. В зависимости от вариативности размеров элементов всё также могут наблюдаться пробелы, которые сетка не сможет заполнить. 
+Сложно назвать это приближение действительно достойной заменой полноценной раскладки Masonry, со свойственными ему ограничениями. Нарушение визуального порядка элементов является серьёзной проблемой. В зависимости от вариативности размеров элементов всё также могут наблюдаться пробелы, которые сетка не сможет заполнить.
 
 В сравнении с другими аналогичными решениями оно отзывчиво, имеет отличную производительность благодаря небольшому использованию JavaScript. Идея хорошо показала себя при использовании разметки фотогалереи, изображения сохраняют свои пропорции, эффективно заполняя доступное пространство. Идея кажется простой, а простота всегда является плюсом.
 

--- a/src/content/blogpost/project-euler/problem-001/index.en.svx
+++ b/src/content/blogpost/project-euler/problem-001/index.en.svx
@@ -4,7 +4,6 @@ description: "The Project Euler #1 solution."
 keywords: [ "project euler", "math" ]
 lang: en
 layout: blogpost
-published: true
 series: "project-euler"
 slug: "project-euler-1"
 title: "Project Euler #1: Multiples of 3 or 5"

--- a/src/content/blogpost/project-euler/problem-001/index.ru.svx
+++ b/src/content/blogpost/project-euler/problem-001/index.ru.svx
@@ -4,7 +4,6 @@ description: "Решаем Проект Эйлера, проблема №1: Ч�
 keywords: [ "project euler", "math" ]
 lang: ru
 layout: blogpost
-published: true
 series: "project-euler"
 slug: "проект-эйлера-1"
 title: "Проект Эйлера #1: Числа, кратные 3 или 5"

--- a/src/content/blogpost/project-euler/problem-002/index.ru.svx
+++ b/src/content/blogpost/project-euler/problem-002/index.ru.svx
@@ -4,7 +4,6 @@ description: "Решаем Проект Эйлера, проблема №2: Ч�
 keywords: [ "project euler", "math" ]
 lang: ru
 layout: blogpost
-published: true
 series: "project-euler"
 slug: "проект-эйлера-2"
 title: "Проект Эйлера #2: Чётные числа Фибоначчи"
@@ -23,7 +22,7 @@ updated: 2021-06-13T00:00:00.000Z
 ```math
 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, ...
 ```
-	
+
 Найти сумму всех чётных членов последовательности, значения которых не превышают четыре миллиона.
 
 </EulerProblem>
@@ -44,7 +43,7 @@ def fibonacci_sequence(limit: int) -> int:
   while a < limit:
     yield a
     a, b = b, a + b
-    
+
 def even_fib_sum(limit: int) -> int:
   return sum([ item for item in fibonacci_sequence(limit) if item % 2 == 0 ])
 ```
@@ -101,7 +100,7 @@ def fibonacci_sequence_even(limit: int) -> int:
   while a < limit:
     yield a
     a, b = b, 4 * b + a
-    
+
 def even_fib_sum(limit: int) -> int:
   return sum([ item for item in fibonacci_sequence_even(limit) ])
 ```

--- a/src/content/blogpost/project-euler/problem-006/Index.en.svx
+++ b/src/content/blogpost/project-euler/problem-006/Index.en.svx
@@ -4,7 +4,6 @@ description: "Solving the Project Euler problem #6."
 keywords: [ "project euler", "math" ]
 lang: en
 layout: blogpost
-published: true
 series: "project-euler"
 slug: "project-euler-6"
 title: "Project Euler #6: Sum square difference"

--- a/src/content/blogpost/project-euler/problem-006/index.ru.svx
+++ b/src/content/blogpost/project-euler/problem-006/index.ru.svx
@@ -4,7 +4,6 @@ description: "Решаем задачу Проекта Эйлера #6"
 keywords: [ "project euler", "math" ]
 lang: ru
 layout: blogpost
-published: true
 series: "project-euler"
 slug: "проект-эйлера-6"
 title: "Проект Эйлера #6: Разность квадратичных сумм"

--- a/src/content/blogpost/radix/index.ru.svx
+++ b/src/content/blogpost/radix/index.ru.svx
@@ -1,10 +1,10 @@
 ---
 created: 2022-10-14T17:24:00.000Z
 description: "Разберёмся в том, как устроена система обозначения чисел и как мы к этому пришли."
+draft: true
 keywords: [ "math", "radix", "numbers" ]
 lang: ru
 layout: blogpost
-published: false
 slug: "системы-счисления"
 title: "Системы счисления"
 ---

--- a/src/content/blogpost/where-do-aperture-numbers-come-from/index.en.svx
+++ b/src/content/blogpost/where-do-aperture-numbers-come-from/index.en.svx
@@ -4,7 +4,6 @@ description: "Let's find out, why aperture numbers are as they are and where do 
 keywords: [ "photography", "aperture", "f-number" ]
 lang: en
 layout: blogpost
-published: true
 slug: "where-do-aperture-numbers-come-from"
 title: "Where do aperture numbers come from?"
 translation: { lang: "русский", slug: "откуда-берутся-числа-диафрагмы" }

--- a/src/content/blogpost/where-do-aperture-numbers-come-from/index.ru.svx
+++ b/src/content/blogpost/where-do-aperture-numbers-come-from/index.ru.svx
@@ -4,7 +4,6 @@ description: "Попробуем разобраться, почему диафр
 keywords: [ "photography", "aperture", "f-number" ]
 lang: ru
 layout: blogpost
-published: true
 slug: "откуда-берутся-числа-диафрагмы"
 title: "Откуда берутся числа диафрагмы?"
 translation: { lang: "english", slug: "where-do-aperture-numbers-come-from" }

--- a/src/lib/utils/query.ts
+++ b/src/lib/utils/query.ts
@@ -2,7 +2,7 @@ type Matcher<T> = (value: T) => boolean;
 
 /**
  * Describes a query option:
- * 
+ *
  * - value;
  * - validator: validates a query option value;
  * - matcher: a curried function to match an item.
@@ -31,7 +31,7 @@ export function find<T>(items: T[], query: Query<T>, { limit, sort }: QueryOptio
 
 	for (const key of Object.keys(query)) {
 		const { value, validator, matcher } = query[key];
-		if (value && validator(value)) {
+		if (validator(value)) {
 			matchers.push(matcher(value));
 		}
 	}

--- a/src/routes/[locale]/blog/+page.svelte
+++ b/src/routes/[locale]/blog/+page.svelte
@@ -21,15 +21,15 @@
 	const queryOptions: Query<Blogpost> = {
 		"content-lang": {
 			value: [ $locale ],
-			validator: (value) => value.length > 0,
+			validator: (value) => Array.isArray(value) && value.length > 0,
 			matcher: (value) => (item) => value.includes(item.lang)
 		},
 		"content-topics": {
-			validator: (value) => value.length > 0,
+			validator: (value) => Array.isArray(value) && value.length > 0,
 			matcher: (value) => (item) => value.every(keyword => item.keywords.includes(keyword))
 		},
 		"content-series": {
-			validator: (value) => value.length > 0,
+			validator: (value) => Array.isArray(value) && value.length > 0,
 			matcher: (value) => (item) => item.series === value[0]
 		}
 	};

--- a/src/routes/[locale]/home/+page.ts
+++ b/src/routes/[locale]/home/+page.ts
@@ -9,8 +9,8 @@ export const load: PageLoad = async ({ params }) => {
 	const { locale = "en"} = params as { locale: Locale };
 
 	try {
-		const [	blogposts, photos, projects ] = await Promise.all([
-			getBlogposts({ lang: locale }),
+		const [ blogposts, photos, projects ] = await Promise.all([
+			getBlogposts({ lang: locale, draft: false }),
 			getGalleryItems(),
 			getProjects({ featured: true }, { limit: 4 })
 		]);

--- a/src/routes/api/blogpost/[slug]/+server.ts
+++ b/src/routes/api/blogpost/[slug]/+server.ts
@@ -11,7 +11,8 @@ export const GET: RequestHandler = async ({ params }) => {
 	}
 
 	const data: Blogpost[] = await getBlogposts({
-		slug: decodeURI(slug)
+		slug: decodeURI(slug),
+		draft: false
 	}, { limit: 1 });
 
 	return new Response(

--- a/src/routes/api/blogposts/+server.ts
+++ b/src/routes/api/blogposts/+server.ts
@@ -1,16 +1,14 @@
-import { dev } from "$app/environment";
+import { dev, prerendering } from "$app/environment";
 import { getBlogposts } from "@data/posts";
 import type { RequestHandler } from "@sveltejs/kit/types";
 import type { Blogpost } from "@types";
 
 export const GET: RequestHandler = async () => {
-	const published = !dev
-		? { published: true }
+	const status = !dev || prerendering
+		? { draft: false }
 		: {};
 
-	const data: Blogpost[] = await getBlogposts({
-		...published
-	});
+	const data: Blogpost[] = await getBlogposts(status);
 
 	return new Response(
 		JSON.stringify(data)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,11 +17,11 @@ export interface Page<T> {
 export interface BlogpostMetadata {
 	created: string;
 	description: string;
+	draft?: boolean;
 	filepath: string;
 	keywords: string[];
 	lang: Locale;
 	layout?: string;
-	published?: boolean;
 	series: string;
 	slug: string;
 	title: string;


### PR DESCRIPTION
Refactored blogpost metakey from `published` to `draft`, as it is easier to mark the posts that should not be published.
While refactoring found and fixed the `find()` helper, it was not allowing `falsy` values. The `validator` should handle that.