### PR TITLE
feat: remove github api, store data in pages

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,33 +1,22 @@
 import { find } from "@utils/query";
-import { fetchJSON } from "@utils/helpers";
 import type { QueryItem } from "@utils/query";
-import type { Project, ProjectPageData, GithubAPIRepo, Page } from "../types";
+import type { Project, Page } from "../types";
 
 interface Options {
 	limit?: number;
 }
 
 /**
- * There are 3 sources of project data:
- *
- * 	1. The locale specific data stored in mdx pages;
- * 	2. The data from Github API;
- *
- * I have to use 2 sources as I have to translate some data and cannot store
- * everything locally or via Github.
- */
-
-/**
  * Retrieves data stored in project pages.
  */
 const getProjectPageData = async () => {
 	try {
-		const projects: ProjectPageData[] = [];
+		const projects: Project[] = [];
 		const modules = import.meta.glob("/src/content/project/*/*.svx");
 
 		// the key is filename, we do not need it here
 		for await (const [ , module ] of Object.entries(modules)) {
-			const { metadata } = await module() as Page<ProjectPageData>;
+			const { metadata } = await module() as Page<Project>;
 			projects.push(metadata);
 		}
 
@@ -38,33 +27,8 @@ const getProjectPageData = async () => {
 	}
 };
 
-const getProjectGithubData = async (items: ProjectPageData[] = []) => {
-	const projects: Project[] = [];
-
-	try {
-		for await (const project of items) {
-			const data = await fetchJSON<GithubAPIRepo>(`https://api.github.com/repos/${project.repository}`);
-			const { homepage, html_url: github, language, topics } = data;
-
-			projects.push({
-				...project,
-				homepage,
-				github,
-				language,
-				topics
-			});
-		}
-
-		return projects;
-
-	} catch (error) {
-		console.error(`Cannot retrieve project data from Github: ${error.message}`);
-	}
-};
-
 export const getProjects = async ({ lang, name, featured }: Partial<Project> = {}, { limit }: Options = {}): Promise<Project[]> => {
-	const pageData = await getProjectPageData();
-	const projects = await getProjectGithubData(pageData);
+	const data = await getProjectPageData();
 
 	type Query<T> = {
 		"featured": QueryItem<boolean, T>;
@@ -90,5 +54,5 @@ export const getProjects = async ({ lang, name, featured }: Partial<Project> = {
 		}
 	};
 
-	return find(projects, query, { limit });
+	return find(data, query, { limit });
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,21 +48,9 @@ export interface Blogpost extends Omit<BlogpostMetadata, "created" | "updated" |
 }
 
 /**
- * `Github Rest API` Project data interface.
- */
-export interface GithubAPIRepo {
-	name: string;
-	description: string;
-	homepage: string;
-	html_url: string;
-	language: string;
-	topics: string[];
-}
-
-/**
  * Project Page Frontmatter data interface.
  */
-export interface ProjectPageData {
+export interface Project {
 	description: string;
 	featured?: boolean;
 	lang: Locale;
@@ -75,10 +63,6 @@ export interface ProjectPageData {
 	type: "string";
 	updated: string;
 	website?: string;
-}
-
-export interface Project extends ProjectPageData, Omit<GithubAPIRepo, "html_url"> {
-	github: string;
 }
 
 export type { GalleryItem } from "@components";


### PR DESCRIPTION
Github API is problematic, too much times cannot build because of rate-limit that somehow always capped.